### PR TITLE
RP2040 can only handle 16 PWM channels

### DIFF
--- a/Template/Community/boards/mobiflight_template_raspberry_pico.board.json
+++ b/Template/Community/boards/mobiflight_template_raspberry_pico.board.json
@@ -148,63 +148,63 @@
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 16
       },
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 17
       },
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 18
       },
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 19
       },
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 20
       },
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 21
       },
       {
         "isAnalog": false,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Pin": 22
       },
       {
         "isAnalog": true,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Name": "A0",
         "Pin": 26
       },
       {
         "isAnalog": true,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Name": "A1",
         "Pin": 27
       },
       {
         "isAnalog": true,
         "isI2C": false,
-        "isPWM": true,
+        "isPWM": false,
         "Name": "A2",
         "Pin": 28
       }


### PR DESCRIPTION
## Description of changes

Raspberry Pico can handle only 16 PWM channels. If more are defined, they get duplicated.
Like the standard FW pins 0 to 15 are defined for allowed PWM pins.
If also using pins 16 to 29, pins 0 to 15 would get overriden and are not more PWM capable.
