### PR TITLE
Added helper script to copy the Community folders to local install

### DIFF
--- a/deploy_community.py
+++ b/deploy_community.py
@@ -1,0 +1,69 @@
+import shutil
+import os
+import re
+from pathlib import Path
+
+def find_custom_source_folder():
+    """Find the custom_source_folder value from platformio.ini files"""
+    # Script is in project root directory
+    project_root = Path(__file__).parent
+
+    # Search for *_platformio.ini files in subdirectories (e.g., Template/MyCustomDevice_platformio.ini)
+    ini_files = list(project_root.glob("*/*_platformio.ini"))
+
+    if not ini_files:
+        raise FileNotFoundError("No *_platformio.ini file found in project")
+
+    # Parse the first one found
+    ini_file = ini_files[0]
+    print(f"Found platformio.ini: {ini_file}")
+
+    with open(ini_file, 'r') as f:
+        content = f.read()
+        # Look for custom_source_folder = CC_G5
+        match = re.search(r'custom_source_folder\s*=\s*(\S+)', content)
+        if match and not match.group(1).startswith('${'):
+            return match.group(1)
+
+    raise ValueError("custom_source_folder not found in platformio.ini")
+
+try:
+    # Auto-discover the project folder name
+    project_folder = find_custom_source_folder()
+    print(f"Project folder: {project_folder}")
+
+    # Get the project root directory (script is in project root)
+    project_root = Path(__file__).parent
+    source_dir = project_root / project_folder / "Community"
+
+    print(f"Project root: {project_root}")
+    print(f"Source directory: {source_dir}")
+    print(f"Source exists: {source_dir.exists()}")
+
+    if not source_dir.exists():
+        raise FileNotFoundError(f"Community folder not found at {source_dir}")
+
+    # Destination directory (using USERPROFILE environment variable)
+    dest_dir = Path.home() / "AppData" / "Local" / "MobiFlight" / "MobiFlight Connector" / "Community" / project_folder
+
+    print(f"Destination directory: {dest_dir}")
+
+    # Create destination directory if it doesn't exist
+    # Check if MobiFlight Community folder exists
+    community_base = dest_dir.parent
+    if not community_base.exists():
+      raise FileNotFoundError(f"MobiFlight Community folder not found at: {community_base}\nPlease verify MobiFlight Connector is installed at the standard location or update script.")
+
+    # Create the project-specific folder
+    dest_dir.mkdir(exist_ok=True)
+    print(f"Destination created/verified")
+
+    # Copy all contents from source to destination, overwriting existing files
+    shutil.copytree(source_dir, dest_dir, dirs_exist_ok=True)
+
+    print(f"\033[92mSuccessfully copied contents from {source_dir} to {dest_dir}\033[0m")
+
+except Exception as e:
+    print(f"\033[91m*********Error: {e}\033[0m")
+    import traceback
+    traceback.print_exc()


### PR DESCRIPTION
## Description of changes

Added deploy_community.py in the root directory.

Automates deployment of MobiFlight Community Device's Community folder files to the local MF install directory for testing during development. 

  - Auto-discovers the custom device folder name by parsing *_platformio.ini files for custom_source_folder
  - Copies all files from {project_folder}/Community/ to the user's MobiFlight Connector Community folder
  - Uses Path.home() to automatically resolve the current user's directory
  - Validates that both source and MobiFlight directories exist before copying
  - Handles and alerts on errors/missing directories.
  - Can be run by opening a shell windows and running 'python.exe deploy_community.py'

Fixes #21 by adding deploy_community.py script.
