### PR TITLE
Add Pico2 support

### DIFF
--- a/Template/Community/boards/mobiflight_template_raspberry_pico2.board.json
+++ b/Template/Community/boards/mobiflight_template_raspberry_pico2.board.json
@@ -1,0 +1,213 @@
+{
+    "$schema": "./mfboard.schema.json",
+    "UsbDriveSettings": {
+      "VolumeLabel": "RPI-RP2",
+      "VerificationFileName": "INFO_UF2.TXT"
+    },
+    "Connection": {
+      "ConnectionDelay": 1250,
+      "DelayAfterFirmwareUpdate": 1250,
+      "DtrEnable": true,
+      "EEPROMSize": 1496,
+      "ExtraConnectionRetry": false,
+      "ForceResetOnFirmwareUpdate": true,
+      "MessageSize": 64
+    },
+    "HardwareIds": ["^VID_2E8A&PID_F00A"],
+    "Info": {
+      "CanInstallFirmware": true,
+      "CanResetBoard": true,
+      "FirmwareBaseName": "mobiflight_template_raspberrypico2",
+      "FirmwareExtension": "uf2",
+      "FriendlyName": "Mobiflight Template RaspiPico2",
+      "LatestFirmwareVersion": "0.0.1",
+      "MobiFlightType": "Mobiflight Template RaspiPico2",
+      "ResetFirmwareFile": "reset.raspberry_pico_flash_nuke.uf2",
+      "CustomDeviceTypes": [
+        "MOBIFLIGHT_TEMPLATE",
+        "MOBIFLIGHT_TEMPLATE2"
+      ],
+      "Community": {
+        "Project": "Your Project",
+        "Website": "https://YourWebsite.com",
+        "Docs": "https://YourWebsite.com",
+        "Support": "https://YourWebsite.com"
+      }
+    },
+    "ModuleLimits": {
+      "MaxAnalogInputs": 3,
+      "MaxInputShifters": 6,
+      "MaxButtons": 26,
+      "MaxEncoders": 13,
+      "MaxLcdI2C": 2,
+      "MaxLedSegments": 6,
+      "MaxOutputs": 26,
+      "MaxServos": 8,
+      "MaxShifters": 6,
+      "MaxSteppers": 6,
+      "MaxInputMultiplexer": 6,
+      "MaxCustomDevices": 5
+    },
+    "Pins": [
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 0
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 1
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 2
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 3
+      },
+      {
+        "isAnalog": false,
+        "isI2C": true,
+        "isPWM": true,
+        "Pin": 4
+      },
+      {
+        "isAnalog": false,
+        "isI2C": true,
+        "isPWM": true,
+        "Pin": 5
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 6
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 7
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 8
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 9
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 10
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 11
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 12
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 13
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 14
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": true,
+        "Pin": 15
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 16
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 17
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 18
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 19
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 20
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 21
+      },
+      {
+        "isAnalog": false,
+        "isI2C": false,
+        "isPWM": false,
+        "Pin": 22
+      },
+      {
+        "isAnalog": true,
+        "isI2C": false,
+        "isPWM": false,
+        "Name": "A0",
+        "Pin": 26
+      },
+      {
+        "isAnalog": true,
+        "isI2C": false,
+        "isPWM": false,
+        "Name": "A1",
+        "Pin": 27
+      },
+      {
+        "isAnalog": true,
+        "isI2C": false,
+        "isPWM": false,
+        "Name": "A2",
+        "Pin": 28
+      }
+    ]
+  }
+  

--- a/Template/MyCustomDevice_platformio.ini
+++ b/Template/MyCustomDevice_platformio.ini
@@ -173,3 +173,36 @@ custom_core_firmware_version = ${env_template.custom_core_firmware_version}	; do
 custom_community_project = ${env_template.custom_community_project}			; don't change this one!
 custom_source_folder = ${env_template.custom_source_folder}					; don't change this one!
 custom_zip_filename = ${env_template.custom_zip_filename}			; don't change this one!
+
+; Build settings for the Raspberry Pico2 with Custom Firmware Template
+[env:mobiflight_template_raspberrypico2]
+platform = https://github.com/maxgerhardt/platform-raspberrypi.git
+board = rpipico2
+framework = arduino
+board_build.core = earlephilhower
+board_build.filesystem_size = 0M
+lib_ldf_mode = chain+
+upload_protocol = mbed
+build_flags =
+	${env_template.build_flags}										; don't change this one!
+	'-DMOBIFLIGHT_TYPE="Mobiflight Template RaspiPico2"'			; this must match with "MobiFlightType" within the .json file
+	'-DMOBIFLIGHT_NAME="Mobiflight Template"'						; this will show up as Name in the settings dialog unless it gets change from there
+	-DMEMLEN_CONFIG=1496											; max. size for config which wil be stored in EEPROM
+	-DMEMLEN_NAMES_BUFFER=1000										; max. size for configBuffer, contains only names from inputs
+	-DMF_MAX_DEVICEMEM=1000											; max. memory size for devices
+build_unflags =
+	;-DMF_STEPPER_SUPPORT											; this is just an example how to deactivate a device
+build_src_filter =
+	${env.build_src_filter}											; don't change this one!
+	${env_template.build_src_filter}								; don't change this one!
+lib_deps =
+	${env.lib_deps}													; don't change this one!
+	${env_template.lib_deps}										; don't change this one!
+	${env.custom_lib_deps_Pico}										; don't change this one!
+monitor_speed = 115200												; don't change this one!
+extra_scripts = 
+	${env.extra_scripts}											; don't change this one!
+custom_core_firmware_version = ${env_template.custom_core_firmware_version}	; don't change this one!
+custom_community_project = ${env_template.custom_community_project}			; don't change this one!
+custom_source_folder = ${env_template.custom_source_folder}					; don't change this one!
+custom_zip_filename = ${env_template.custom_zip_filename}			; don't change this one!


### PR DESCRIPTION
## Description of changes

With core FW version 3.1.0 Raspberry Pico2 support was added. For using this board with a community device a new environment must be added to the `MyCustomDevice_platformio.ini` and an additional board.json file is required.
These changes are done within this PR.